### PR TITLE
Small improvements

### DIFF
--- a/src/BurnAuth.ts
+++ b/src/BurnAuth.ts
@@ -3,15 +3,20 @@ import {
     Field
 } from 'o1js';
 
-/** When a token is issued, issuer and holder should agree on who can revoke the token */
-class RevocationPolicy extends Struct ({
+/** When a token is issued, issuer and holder should agree on who can revoke the token
+ * 
+ * Names are according to ERC 5484, to reduce mental load on 
+ * cross-platform developers.
+ * 
+ */
+class BurnAuth extends Struct ({
     type: Field,
 }) {
     public static types = {
         // the issuer has the right to revoke tokens
         issuerOnly: Field(0),
         // only the holder of the token can revoke it
-        holderOnly: Field(1),
+        ownerOnly: Field(1),
         // a token can only be revoked if issuer and holder agree
         both: Field(2),
         // tokens are indestructible
@@ -19,4 +24,4 @@ class RevocationPolicy extends Struct ({
     };
 }
 
-export { RevocationPolicy };
+export { BurnAuth };

--- a/src/SoulboundErrors.ts
+++ b/src/SoulboundErrors.ts
@@ -4,10 +4,10 @@ const SoulboundErrors = {
     alreadyExists:
       'Cannot issue token, because it has already been issued.',
     wrongPolicy:
-      'RevocationPolicy does not match what is expected by the issuer',
-    missingHolderSignature:
-      'This requires a signature from the token holder',
+      'BurnAuth does not match what is expected by the issuer',
+    missingOwnerSignature:
+      'This requires a signature from the token owner',
     unrevocable:
-      'This token cannot be revoked as per the RevocationPolicy',
+      'This token cannot be revoked as per the BurnAuth',
 };
 export { SoulboundErrors };

--- a/src/SoulboundMetadata.ts
+++ b/src/SoulboundMetadata.ts
@@ -1,11 +1,11 @@
 import { Field, PublicKey, Poseidon, UInt32, Struct } from 'o1js';
-import { RevocationPolicy } from './RevocationPolicy';
+import { BurnAuth } from './BurnAuth';
 
 /** Metadata that defines a token */
 class SoulboundMetadata extends Struct({
-    holderKey: PublicKey,
+    ownerKey: PublicKey,
     issuedBetween: [UInt32, UInt32],
-    revocationPolicy: RevocationPolicy,
+    burnAuth: BurnAuth,
     attributes: [Field],
 }) {
     hash(): Field {

--- a/src/SoulboundToken.ts
+++ b/src/SoulboundToken.ts
@@ -43,21 +43,32 @@ class SoulboundToken
         'update-merkle-root': Field,
       };
     // Root of the `MerkleMap` that contains all the tokens
-    @state(Field) root = State<Field>();
+    @state(Field) public readonly root = State<Field>();
     // In this example, all tokens from this contract can be
     // revoked according to the same policy
-    @state(RevocationPolicy) revocationPolicy = State<RevocationPolicy>();
-    @state(PublicKey) issuerKey = State<PublicKey>();
+    @state(RevocationPolicy) public readonly revocationPolicy = State<RevocationPolicy>();
+    @state(PublicKey) public readonly issuerKey = State<PublicKey>();
+    @state(Bool) public readonly initialised = State<Bool>()
 
     @method init(): void {
         super.init();
         const emptyMap = new MerkleMap;
         this.updateRoot(emptyMap.getRoot());
+        this.initialised.set(Bool(false));
     }
 
     @method initialise(revocationPolicy: RevocationPolicy, issuerKey: PublicKey): void {
+        // this check prevents anyone from overwriting the state
+        // by calling initialise again
+        // Note that in production, you would want to ensure that only
+        // the creator of the token can call initialise in the first place.
+        // One way of doing that is by hard-coding an initial public key into
+        // the code of the contract.
+        this.initialised.requireEquals(this.initialised.get());
+        this.initialised.get().assertFalse();
         this.revocationPolicy.set(revocationPolicy);
         this.issuerKey.set(issuerKey);
+        this.initialised.set(Bool(true));
     }
 
     /** Issue a token

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from './RevocationPolicy'
+export * from './BurnAuth'
 export * from './SoulboundMetadata'
 export * from './SoulboundToken'

--- a/test/SoulboundTokenDriver.ts
+++ b/test/SoulboundTokenDriver.ts
@@ -1,4 +1,4 @@
-import { Account, Field, MerkleMap, MerkleMapWitness, Mina, PrivateKey, PublicKey, Signature } from "o1js";
+import { Account, Bool, Field, MerkleMap, MerkleMapWitness, Mina, PrivateKey, PublicKey, Signature } from "o1js";
 import { SoulboundMetadata , SoulboundRequest } from "../src/SoulboundMetadata";
 import { SoulboundToken, TokenState } from "../src/SoulboundToken";
 import { RevocationPolicy } from "../src";
@@ -37,7 +37,7 @@ class SoulboundTokenDriver{
         });
         await tx2.prove();
         await tx2.sign([this.feePayerAccount.privateKey, this.issuerKey]).send();
-      }
+    }
 
     public async issue(request: SoulboundRequest, signature: Signature) {
         const key = request.metadata.hash();

--- a/test/SoulboundTokenDriver.ts
+++ b/test/SoulboundTokenDriver.ts
@@ -1,7 +1,7 @@
 import { Account, Bool, Field, MerkleMap, MerkleMapWitness, Mina, PrivateKey, PublicKey, Signature } from "o1js";
 import { SoulboundMetadata , SoulboundRequest } from "../src/SoulboundMetadata";
 import { SoulboundToken, TokenState } from "../src/SoulboundToken";
-import { RevocationPolicy } from "../src";
+import { BurnAuth } from "../src";
 import { SoulboundErrors } from "../src/SoulboundErrors";
 
 type Account = {publicKey: PublicKey; privateKey: PrivateKey;}
@@ -10,19 +10,19 @@ class SoulboundTokenDriver{
     tokenMap: MerkleMap;
     issuer: SoulboundToken;
     issuerKey: PrivateKey;
-    revocationPolicy: RevocationPolicy;
+    burnAuth: BurnAuth;
     feePayerAccount: Account;
 
     constructor(
             tokenMap: MerkleMap,
             issuer: SoulboundToken,
             issuerKey: PrivateKey,
-            revocationPolicy: RevocationPolicy,
+            burnAuth: BurnAuth,
             feePayerAccount: Account) {
         this.tokenMap = tokenMap;
         this.issuer = issuer;
         this.issuerKey = issuerKey;
-        this.revocationPolicy = revocationPolicy;
+        this.burnAuth = burnAuth;
         this.feePayerAccount = feePayerAccount;
     }
 
@@ -33,7 +33,7 @@ class SoulboundTokenDriver{
         await tx.prove();
         await tx.sign([this.feePayerAccount.privateKey, this.issuerKey]).send();
         const tx2 = await Mina.transaction(this.feePayerAccount.publicKey, () => {
-            this.issuer.initialise(this.revocationPolicy, this.issuerKey.toPublicKey())
+            this.issuer.initialise(this.burnAuth, this.issuerKey.toPublicKey())
         });
         await tx2.prove();
         await tx2.sign([this.feePayerAccount.privateKey, this.issuerKey]).send();
@@ -51,19 +51,19 @@ class SoulboundTokenDriver{
         this.tokenMap.set(key, TokenState.types.issued);
     }
 
-    public async revoke(request: SoulboundRequest, holderSignature?: Signature) {
+    public async revoke(request: SoulboundRequest, ownerSignature?: Signature) {
         const key = request.metadata.hash();
         const witness = this.tokenMap.getWitness(key);
         let tx: Mina.Transaction;
-        switch (request.metadata.revocationPolicy.type) {
-            case RevocationPolicy.types.holderOnly:
-                if (typeof holderSignature !== undefined) {
+        switch (request.metadata.burnAuth.type) {
+            case BurnAuth.types.ownerOnly:
+                if (typeof ownerSignature !== undefined) {
                     tx = await Mina.transaction(this.feePayerAccount.publicKey, () => {
-                        this.issuer.revokeHolder(request, witness, holderSignature!);
+                        this.issuer.revokeOwner(request, witness, ownerSignature!);
                     })
-                } else { throw(SoulboundErrors.missingHolderSignature) }
+                } else { throw(SoulboundErrors.missingOwnerSignature) }
                 break;
-            case RevocationPolicy.types.issuerOnly:
+            case BurnAuth.types.issuerOnly:
                 // In a real world application, here would be some business logic
                 // to determine if the revocation should be permitted
                 const issuerSignature = Signature.create(
@@ -73,22 +73,22 @@ class SoulboundTokenDriver{
                     this.issuer.revokeIssuer(request, witness, issuerSignature);
                 })
                 break;
-            case RevocationPolicy.types.both:
+            case BurnAuth.types.both:
                 // Again, insert a check whether the issuer wants to agree to
                 // the token being revoked
-                if (typeof holderSignature !== undefined) {
+                if (typeof ownerSignature !== undefined) {
                     const issuerSignature = Signature.create(
                         this.issuerKey,
                         SoulboundRequest.toFields(request));
                     tx = await Mina.transaction(this.feePayerAccount.publicKey, () => {
-                        this.issuer.revokeBoth(request, witness, holderSignature!, issuerSignature);
+                        this.issuer.revokeBoth(request, witness, ownerSignature!, issuerSignature);
                     })
-                } else { throw(SoulboundErrors.missingHolderSignature) }
+                } else { throw(SoulboundErrors.missingOwnerSignature) }
                     break;
-            case RevocationPolicy.types.neither:
+            case BurnAuth.types.neither:
                 throw(SoulboundErrors.unrevocable);
             default:
-                throw('unexpected value for revocationPolicy')
+                throw('unexpected value for burnAuth')
         }
         await tx.prove();
         await tx.sign([this.feePayerAccount.privateKey]).send();


### PR DESCRIPTION
- prevents the initialisation to be called more than once, overwriting the contract state
- Change nomenclature around permission to revoke tokens to be in line with existing EXR 5484, to ease adoption.